### PR TITLE
remove parseHelp, as it's inherit to load - otherwise help functions are loaded twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ module.exports = function(robot) {
   if (fs.existsSync(path)) {
     fs.readdirSync(path).forEach(function(file) {
       robot.loadFile(path, file);
-      robot.parseHelp(Path.join(path, file));
     });
   }
 };


### PR DESCRIPTION
see: https://github.com/github/hubot/blob/master/src/robot.coffee#L341
